### PR TITLE
Fix/keyboard on tab gesture#257

### DIFF
--- a/MSG/MSG/View/GameSetting/GameSettingView.swift
+++ b/MSG/MSG/View/GameSetting/GameSettingView.swift
@@ -119,8 +119,10 @@ extension GameSettingView {
                             
                             HStack {
                                 ZStack(alignment: .leading) {
-                                    Text(gameSettingViewModel.targetMoney.insertComma)
-                                        .multilineTextAlignment(.leading)
+                                    if !gameSettingViewModel.targetMoney.insertComma.isEmpty {
+                                        Text("\(gameSettingViewModel.targetMoney.insertComma)원")
+                                            .multilineTextAlignment(.leading)
+                                    }
                                     TextField("", text: $gameSettingViewModel.targetMoney)
                                         .placeholder(when: gameSettingViewModel.targetMoney.isEmpty) {
                                             Text("1,000만원 미만으로 입력하세요")
@@ -386,7 +388,7 @@ extension GameSettingView {
                         dismiss()
                     } else {
                         print("도전장 보내짐?")
-                        let localNotification = LocalNotification(identifier: UUID().uuidString, title: "도전장을 보냈습니다.", body: "도전을 받게되면 시작됩니다.", timeInterval: 1, repeats: false)
+                        let localNotification = LocalNotification(identifier: UUID().uuidString, title: "도전장을 보냈습니다.", body: "상대방이 도전을 수락하면 시작됩니다.", timeInterval: 1, repeats: false)
                         let challenge = Challenge(
                             id: UUID().uuidString,
                             gameTitle: gameSettingViewModel.title,

--- a/MSG/MSG/View/GameSetting/SoloGameSettingView.swift
+++ b/MSG/MSG/View/GameSetting/SoloGameSettingView.swift
@@ -97,8 +97,11 @@ struct SoloGameSettingView: View {
                             
                             HStack {
                                 ZStack(alignment: .leading) {
-                                    Text(gameSettingViewModel.targetMoney.insertComma)
-                                        .multilineTextAlignment(.leading)
+                                    if !gameSettingViewModel.targetMoney.insertComma.isEmpty {
+                                        Text("\(gameSettingViewModel.targetMoney.insertComma)원")
+                                            .multilineTextAlignment(.leading)
+                                    }
+
                                     TextField("", text: $gameSettingViewModel.targetMoney)
                                         .placeholder(when: gameSettingViewModel.targetMoney.isEmpty) {
                                             Text("1,000만원 미만으로 입력하세요")

--- a/MSG/MSG/View/Home/SpendingWritingView.swift
+++ b/MSG/MSG/View/Home/SpendingWritingView.swift
@@ -161,7 +161,11 @@ struct SpendingWritingView: View {
                                     HStack {
                                         
                                         ZStack(alignment: .leading) {
-                                            Text(spendingViewModel.consumeMoney.insertComma)
+                                            
+                                            if !spendingViewModel.consumeMoney.insertComma.isEmpty {
+                                                Text("\(spendingViewModel.consumeMoney.insertComma)원")
+                                                    .multilineTextAlignment(.leading)
+                                            }
                                             
                                             TextField("", text: $spendingViewModel.consumeMoney)
                                                 .focused($focusField, equals: .consumeMoney)


### PR DESCRIPTION
# 수정사항
GameSettingView, SoloSettingView, SpendingWritingView
*  keyboard onTaoGesture 적용
*   keyboard toolbar 제거
*   한도금액 통화 원 달기
*   도전장 얼럿 수정 -> "상대방이 도전을 수락하면 시작됩니다."