### PR TITLE
[Fix]: 영문 유저 검색시, 버그 수정 #261

### DIFF
--- a/MSG/MSG/RealtimeViewModel.swift
+++ b/MSG/MSG/RealtimeViewModel.swift
@@ -12,7 +12,7 @@ final class RealtimeViewModel: ObservableObject {
     
     @Published var inviteFriendIdArray:[String] = []
     @Published var friendCount: Int = 0
-    @Published var requsetCount: Int = 1
+    @Published var requsetCount: Int = 0
         
     
     

--- a/MSG/MSG/View/FriendSetting/DivideFriendViewModel.swift
+++ b/MSG/MSG/View/FriendSetting/DivideFriendViewModel.swift
@@ -92,7 +92,8 @@ final class DivideFriendViewModel: ObservableObject {
             let id: String = document.documentID
             let docData = document.data()
             let nickName: String = docData["nickName"] as? String ?? ""
-            if (nickName.contains(text.lowercased()) || nickName.contains( text.uppercased())) && (id != Auth.auth().currentUser?.uid) {
+//            nickName.lowercased()
+            if nickName.lowercased().contains(text.lowercased()) && id != Auth.auth().currentUser?.uid {
                 self.searchUserArray.append(id)
             }
         }


### PR DESCRIPTION
## 버그 수정
영문 유저 검색시, 대소문자 구분으로 유저가 검색되지 않는 현상
ex) Hoon 검색 → hoon 변환 → Text(hoon) != DB(Hoon)